### PR TITLE
add missing <mutex> header

### DIFF
--- a/rlbox.h
+++ b/rlbox.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <type_traits>
 #include <map>
+#include <mutex>
 #include <string.h>
 #include <cstdint>
 


### PR DESCRIPTION
Since `rlbox.h` uses things like `std::lock_guard`, it should include the appropriate header.