### PR TITLE
add a stacktemp helper function to the sandbox

### DIFF
--- a/rlbox.h
+++ b/rlbox.h
@@ -1968,6 +1968,16 @@ namespace rlbox
 			return &(this->impl_MaintainAppPtrMap);
 		}
 
+		template<typename T>
+		sandbox_stackarr_helper<T, TSandbox> stacktemp()
+		{
+			const size_t size = sizeof(T);
+			T* argInSandbox = static_cast<T*>(this->impl_pushStackArr(size));
+			memset((void*)argInSandbox, 0, size);
+
+			return sandbox_stackarr_helper<T, TSandbox>(this, argInSandbox, size);
+		}
+
 		template <typename T>
 		inline sandbox_stackarr_helper<T, TSandbox> stackarr(T* arg, size_t size)
 		{


### PR DESCRIPTION
The intent of this function is to get the same effect one would get with
`stackarr`, but without the need for an existing (non-sandboxed)
temporary and the somewhat unintuitive size argument.  Using this in
preference to `mallocInSandbox` also ensures that you don't forget to free
the malloc'd buffer--although you do have to exercise good judgement
about using this function.